### PR TITLE
Changed tests to make sure students aren't allowed to use Song.all as #songs solution

### DIFF
--- a/spec/artist_spec.rb
+++ b/spec/artist_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe "Artist" do
 
   let!(:adele) { Artist.new("Adele") }
+  let!(:drake) { Artist.new("Drake")}
 
     describe "#new" do
       it "is initialized with a name" do
@@ -21,6 +22,8 @@ describe "Artist" do
         expect(adele.songs).to be_a(Array)
         hello = Song.new("Hello")
         hello.artist = adele
+        hotline_bling = Song.new("Hotline Bling")
+        hotline_bling.artist = drake
         expect(adele.songs).to eq([hello])
       end
     end

--- a/spec/artist_spec.rb
+++ b/spec/artist_spec.rb
@@ -47,7 +47,7 @@ describe "Artist" do
 
     describe ".song_count" do
       it "is a class method that returns the total number of songs associated to all existing artists" do
-        expect(Artist.song_count).to eq(3)
+        expect(Artist.song_count).to eq(4)
       end
     end
 end


### PR DESCRIPTION
A student used `Song.all` inside the Artist.songs method and was able to pass the test. I added an additional artist and song to the test file to prevent this from happening.